### PR TITLE
Adds aroace svg flag

### DIFF
--- a/svg/aroace-flag.svg
+++ b/svg/aroace-flag.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   style="enable-background:new 0 0 64 64;"
+   xml:space="preserve"
+   sodipodi:docname="aroace-flag.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs93" /><sodipodi:namedview
+   id="namedview91"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="9.6232814"
+   inkscape:cx="39.071912"
+   inkscape:cy="34.447709"
+   inkscape:window-width="1020"
+   inkscape:window-height="1036"
+   inkscape:window-x="1024"
+   inkscape:window-y="20"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style74">
+	.st0{fill:#3DA542;}
+	.st1{fill:#A7D379;}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#A9A9A9;}
+	.st4{fill:#99A8AE;}
+	.st5{fill:#6E8189;}
+</style>
+<path
+   class="st0"
+   d="M62,12.2c-19.33-8.21-38.67,8.2-58,0c0-1.95,0-5.88,0-7.83c19.33,8.2,38.67-8.21,58,0C62,6.32,62,10.25,62,12.2  z"
+   id="path76"
+   style="fill:#e28c00;fill-opacity:1" />
+<path
+   class="st1"
+   d="M62,19.06c-19.33-8.2-38.67,8.21-58,0c0-1.95,0-5.88,0-7.83c19.33,8.2,38.67-8.21,58,0  C62,13.18,62,17.11,62,19.06z"
+   id="path78"
+   style="fill:#eccd00;fill-opacity:1" />
+<path
+   class="st2"
+   d="M62,25.92c-19.33-8.2-38.67,8.21-58,0c0-1.95,0-5.88,0-7.83c19.33,8.2,38.67-8.21,58,0  C62,20.04,62,23.96,62,25.92z"
+   id="path80" />
+<path
+   class="st3"
+   d="M62,32.77c-19.33-8.2-38.67,8.2-58,0c0-1.95,0-5.88,0-7.83c19.33,8.2,38.67-8.21,58,0  C62,26.89,62,30.82,62,32.77z"
+   id="path82"
+   style="fill:#62aedc;fill-opacity:1" />
+<path
+   d="M62,39.63c-19.33-8.2-38.67,8.2-58,0c0-1.95,0-5.88,0-7.83c19.33,8.2,38.67-8.21,58,0C62,33.75,62,37.68,62,39.63z"
+   id="path84"
+   style="fill:#203856;fill-opacity:1" />
+<path
+   class="st4"
+   d="M2,4.12V62l4,0V4.12C6,1.3,2,1.29,2,4.12z"
+   id="path86" />
+<path
+   class="st5"
+   d="M2.99,2.27c0.57,0.32,1,0.91,1,1.82L4,61.97l2,0V4.09C6,2.18,4.18,1.6,2.99,2.27z"
+   id="path88" />
+</svg>


### PR DESCRIPTION
Adds the aroace flag, as defined [here](https://flag.library.lgbt/flags/aroace/).
This just adds the svg file, as recommended by the readme. Please let me know if there's anything I'm missing, I'd love to contribute to this project!